### PR TITLE
Fix: Audio join flow for BBB 3.0 servers with livekit, revert #107

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,7 +9,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Fixed
 
-- Audio join flow for BBB 3.0 servers with listenOnlyMode=false ([#107])
+- Audio join flow for BBB 3.0 servers with listenOnlyMode=false and livekit ([#107], [#113])
 
 ## [v1.0.0] - 2025-04-28
 
@@ -20,6 +20,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Docs: Readme + OpenAPI
 
 [#107]: https://github.com/THM-Health/BBB-Streaming-Server/pull/107
+[#113]: https://github.com/THM-Health/BBB-Streaming-Server/pull/113
 
 
 [unreleased]: https://github.com/THM-Health/BBB-Streaming-Server/compare/v1.0.0...main

--- a/src/worker/BBBLiveStream.ts
+++ b/src/worker/BBBLiveStream.ts
@@ -132,38 +132,8 @@ export class BBBLiveStream{
 
         await this.page.goto(this.joinUrl);
 
-    
-        // Find listen only button
-        let listenOnlyLocator = '';
-
-        const isMeteor = await this.page.evaluate(() => {
-            return eval('typeof __meteor_runtime_config__') === 'object';
-        });
-        if(isMeteor){
-            // BBB <= 2.7
-            listenOnlyLocator = '[data-test="listenOnlyBtn"]';
-        }
-        else{
-            // BBB >= 3.0
-
-            // Wait for window.meetingClientSettings to be available, wait 10 sec.
-            const clientSettings = await this.getObject('window.meetingClientSettings', 10000);
-            if(clientSettings === undefined){
-                logger.error("Failed to get window.meetingClientSettings");
-                return false;
-            }
-        
-            if(clientSettings.public.app.listenOnlyMode === true){
-                listenOnlyLocator = '[data-test="listenOnlyBtn"]';
-            }
-            else{
-                listenOnlyLocator = '[data-test="helpListenOnlyBtn"]';
-            }
-        }
-
         try{
-            // Wait for listen only button to be available, wait 30 sec.
-            await this.page.locator(listenOnlyLocator).setTimeout(30000).click();
+            await this.page.locator('[data-test="listenOnlyBtn"], [data-test="helpListenOnlyBtn"]').setTimeout(30000).click();
         }
         catch(error){
             logger.error("Failed to find listen only button");
@@ -222,28 +192,6 @@ export class BBBLiveStream{
         }
     }
 
-    /**
-     * Try to get window/document/etc. object
-     * @param object Name of the object to get, e.g. window.meetingClientSettings
-     * @param timeout Time in ms to wait for the object to be available
-     * @returns object or undefined
-     */
-    async getObject(object: string, timeout: number){
-
-        const startTime = Date.now();
-        while (Date.now() - startTime < timeout) {
-            const result = await this.page.evaluate((object: string) => {
-                return eval(object);
-            }, object);
-            if (result !== undefined) {
-                return result;
-            }
-
-            // Wait for 100ms before trying again
-            await new Promise(resolve => setTimeout(resolve, 100));
-        }
-        return undefined;
-    }
 
     pause(){
         this.updateProgress("paused");


### PR DESCRIPTION
Determining the correct listen only button using window.meetingClientSettings (added in PR #107) is not working with livekit enabled.

This PR reverts PR #107 and simply tries to find any of the two possible buttons in the audio dialog and use the first one found.